### PR TITLE
Only store a session with its own properties

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,29 @@
 Software License Agreement (BSD License)
 
-Copyright (c) 2007, Dav Glass <dav.glass@yahoo.com>.
+Copyright (c) 2010, Zazengo / Bart Teeuwisse <bart@zazengo.com>
 All rights reserved.
 
-Redistribution and use of this software in source and binary forms, with or without modification, are
-permitted provided that the following conditions are met:
+Redistribution and use of this software in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above
-  copyright notice, this list of conditions and the
-  following disclaimer.
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above
-  copyright notice, this list of conditions and the
-  following disclaimer in the documentation and/or other
-  materials provided with the distribution.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
 
-* The name of Dav Glass may not be used to endorse or promote products
-  derived from this software without specific prior
-  written permission of Dav Glass.
+    * Neither the name of Zazengo nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ You can also pass several options to the constructor to tweak your session store
 * collection - The collection to save it's data to, defaults to: `sessions`
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
 
-    var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
-    app.use(connect.session({ store: new MongoStore({ server: CustomServer }) }));
+<pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
+app.use(connect.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB Session Storage for Connect Middleware
 
-This module is an addon for Connect Middleware that adds a new Session Storage device.
+This module is an addon for [Connect Middleware](https://github.com/senchalabs/connect) that adds a new [Session Storage device][(https://github.com/senchalabs/connect/blob/master/docs/session.md).
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB Session Storage for Connect Middleware
 
-This module is an addon for [Connect Middleware](https://github.com/senchalabs/connect) that adds a new [Session Storage device][(https://github.com/senchalabs/connect/blob/master/docs/session.md).
+This module is an addon for [Connect Middleware](https://github.com/senchalabs/connect) that adds a new [Session Storage device](https://github.com/senchalabs/connect/blob/master/docs/session.md).
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
-# MongoDB Session Storage for ExpressJS
+# MongoDB Session Storage for Connect Middleware
 
-This module is an addon for ExpressJS that adds a new Session Storage device.
+This module is an addon for Connect Middleware that adds a new Session Storage device.
 
 
 ## Install
 
-    npm install express-session-mongo
+    npm install connect-session-mongo
 
 ## Usage
 
 The standard usage, is to just pass an instantiated `MongoStore` instance to the session plugin. 
 
-    var xp = require('express'),
-        MongoStore = require('express-session-mongo');
+    var connect = require('connect'),
+        MongoStore = require('connect-session-mongo');
 
-    var app = xp.createServer();
+    var app = connect.createServer();
 
     app.configure(function(){
-        app.use(xp.cookieDecoder());
-        app.use(xp.session({ store: new MongoStore() }));
+        app.use(connect.cookieDecoder());
+        app.use(connect.session({ store: new MongoStore() }));
         app.use(app.router);
     });
 
 You can also pass several options to the constructor to tweak your session store:
 
-* db - The name of the db to use, defaults to: `express-sessions`
+* db - The name of the db to use, defaults to: `connect-sessions`
 * ip - The IP address of the server to connect to, defaults to: `127.0.0.1`
 * port - The Port to connect to, defaults to: `27017`
 * collection - The collection to save it's data to, defaults to: `sessions`
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
 
-<pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
-app.use(xp.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>
-
+    var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
+    app.use(connect.session({ store: new MongoStore({ server: CustomServer }) }));
 
 ## License
 
-Licensed under my standard BSD license.
+Licensed the [BSD license](https://github.com/zazengo/connect-session-mongo/blob/master/LICENSE).
 
 ### Based on these classes
 
 * [Sencha Connect Memory Store](https://github.com/senchalabs/connect/tree/master/lib/connect/middleware/session/memory.js)
 * [ciaranj's express-session-mongodb](https://github.com/ciaranj/express-session-mongodb)
+* [davglass's express-session-mongodb](https://github.com/davglass/express-session-mongodb)

--- a/examples/app.js
+++ b/examples/app.js
@@ -3,14 +3,14 @@
 //Needed for monit/upstart
 process.chdir(__dirname);
 
-var xp = require('express'),
-    MongoStore = require('express-session-mongo');
+var connect = require('connect'),
+    MongoStore = require('connect-session-mongo');
 
-var app = module.exports = xp.createServer();
+var app = module.exports = connect.createServer();
 
 app.configure(function(){
-    app.use(xp.cookieDecoder());
-    app.use(xp.session({ store: new MongoStore() }));
+    app.use(connect.cookieDecoder());
+    app.use(connect.session({ store: new MongoStore() }));
     app.use(app.router);
 });
 

--- a/lib/connect-session-mongo.js
+++ b/lib/connect-session-mongo.js
@@ -2,6 +2,7 @@
 * Based on the following classes:
 * https://github.com/senchalabs/connect/tree/master/lib/connect/middleware/session/memory.js
 * https://github.com/ciaranj/express-session-mongodb
+* https://github.com/davglass/express-session-mongodb
 */
 var mongo = require('mongodb'),
     util = require(process.binding('natives').util ? 'util' : 'sys'),
@@ -24,7 +25,7 @@ var MongoStore = module.exports = function(options) {
     }
     
     var server,
-        dbName = (options.db) ? options.db : 'express-sessions',
+        dbName = (options.db) ? options.db : 'connect-sessions',
         ip = (options.ip) ? options.ip : '127.0.0.1',
         port = (options.port) ? options.port : 27017;
 

--- a/lib/connect-session-mongo.js
+++ b/lib/connect-session-mongo.js
@@ -60,12 +60,13 @@ MongoStore.prototype.set = function(sid, sess, fn) {
                 fn && fn(error);
             } else {
                 sess._sessionid = sid;
-                var method = 'insert';
+                var clone = cloneOwnProperties(sess);
                 if (session_data) {
                     sess.lastAccess = (new Date()).getTime();
-                    method = 'save';
+                    // Add mongo's internal ID so that collection.save() won't create a new object.
+                    clone._id = session_data._id;
                 }
-                collection[method](cloneOwnProperties(sess), function(err, document) {
+                collection.save(clone, function(err, document) {
                     if (err) {
                     } else {
                         fn && fn(null, sess);
@@ -157,4 +158,4 @@ var cloneOwnProperties = function(original) {
     }
   }
   return copy;
-}
+};

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -8,8 +8,7 @@ var mongo = require('mongodb'),
     Store = require('connect').session.Store,
     Db = mongo.Db,
     Connection = mongo.Connection,
-    Server = mongo.Server,
-    BSON = mongo.BSONNative;
+    Server = mongo.Server;
 
 var MongoStore = module.exports = function(options) {
     options = options || {};
@@ -37,7 +36,9 @@ var MongoStore = module.exports = function(options) {
         server= new Server(ip, port, {auto_reconnect: true}, {});
     }
 
-    this._db = new Db( dbName, server, { native_parser:true });
+    // As much as I favor native drivers, the node-mongodb-native native driver isn'this
+    // on par with its pure implementation. E.g. Long.toNumber() doesn't work.
+    this._db = new Db( dbName, server, { native_parser: false });
     this._db.open(function(db) {});
     
 }
@@ -130,17 +131,23 @@ MongoStore.prototype.clear = function() {
 var cleanSessionData = function(json) {
     var data = {};
     for (var i in json) {
+        // Don't return mongo's internal ID for the session.
+        if (i === '_id') { continue; }
         data[i] = json[i];
-        if (data[i] instanceof Object) {
-            if ('low_' in data[i] || 'high_' in data[i]) {
-                data[i] = data[i].toNumber();
-            }
+        // lastAccess is a Unix timestamp which mongo stores as a 2 component Long object. Convert it back to number.
+        if (data[i] instanceof mongo.BSONPure.Long) {
+            data[i] = data[i].toNumber();
         }
-
     }
     return data;
 };
 
+/**
+ * There is a problem in Mongo's Native & Pure drivers in that functions of the session's prototype are also saved to
+ * mongo. Cloning just the session's own properties is a workaround.
+ *
+ * @param original {Object} The session object whose own properties should be cloned.
+ */
 var cloneOwnProperties = function(original) {
   var copy = {};
   for (var i in original) {

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -5,15 +5,15 @@
 */
 var mongo = require('mongodb'),
     util = require(process.binding('natives').util ? 'util' : 'sys'),
-    Session = require('express').session,
+    Store = require('connect').session.Store,
     Db = mongo.Db,
     Connection = mongo.Connection,
     Server = mongo.Server,
     BSON = mongo.BSONNative;
 
-var MongoStore = function(options) {
+var MongoStore = module.exports = function(options) {
     options = options || {};
-    Session.Store.call(this, options);
+    Store.call(this, options);
     
     // Default reapInterval to 10 minutes
     this.reapInterval = options.reapInterval || 600000;
@@ -42,7 +42,7 @@ var MongoStore = function(options) {
     
 }
 
-util.inherits(MongoStore, Session.Store);
+util.inherits(MongoStore, Store);
 
 MongoStore.prototype.reap = function(ms) {
     var thresh = Number(new Date(Number(new Date) - ms));
@@ -63,9 +63,9 @@ MongoStore.prototype.set = function(sid, sess, fn) {
                     sess.lastAccess = (new Date()).getTime();
                     method = 'save';
                 }
-                collection[method](sess, function(err, document) {
+                collection[method](cloneOwnProperties(sess), function(err, document) {
                     if (err) {
-                    } else { 
+                    } else {
                         fn && fn(null, sess);
                     }
                 });
@@ -79,7 +79,7 @@ MongoStore.prototype.get = function(sid, fn) {
         collection.findOne({ _sessionid: sid }, function(err, session_data) {
             if (err) {
                 fn && fn(error);
-            } else { 
+            } else {
                 if (session_data) {
                     session_data = cleanSessionData(session_data);
                 }
@@ -136,10 +136,17 @@ var cleanSessionData = function(json) {
                 data[i] = data[i].toNumber();
             }
         }
-        
+
     }
     return data;
+};
+
+var cloneOwnProperties = function(original) {
+  var copy = {};
+  for (var i in original) {
+    if (original.hasOwnProperty(i)) {
+      copy[i] = original[i];
+    }
+  }
+  return copy;
 }
-
-
-module.exports = MongoStore;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "connect-session-mongo",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "MongoDB Session Store for Connect Middleware",
     "author": "Bart Teeuwisse <bart@zazengo.com>",
     "contributors": ["Dav Glass <davglass@gmail.com>"],

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-    "name": "express-session-mongo",
+    "name": "connect-session-mongo",
     "version": "0.0.1",
-    "description": "MongoDB Session Store for ExpressJS",
-    "author": "Dav Glass <davglass@gmail.com>",
-    "bugs": { "web" : "http://github.com/davglass/express-session-mongo/issues" },
+    "description": "MongoDB Session Store for Connect Middleware",
+    "author": "Bart Teeuwisse <bart@zazengo.com>",
+    "contributors": ["Dav Glass <davglass@gmail.com>"],
+    "bugs": { "web" : "http://github.com/zazengo/connect-session-mongo/issues" },
     "os": ["darwin", "linux"],
     "engines": {
         "node" : ">=0.2.0"
@@ -11,20 +12,19 @@
     "directories": {
         "lib" : "lib"
     },
-    "main": "./lib/express-session-mongo",
+    "main": "./lib/connect-session-mongo",
     "dependencies": {
-        "express": ">=1.0.0rc4",
         "connect": ">=0.2.4",
         "mongodb": ">=0.7.9"
     },
     "licenses":[
         {
             "type" : "BSD",
-            "url" : "http://github.com/davglass/express-session-mongo/blob/master/LICENSE"
+            "url" : "http://github.com/zazengo/connect-session-mongo/blob/master/LICENSE"
         }
     ],
     "repository": {
         "type":"git",
-        "url":"http://github.com/davglass/express-session-mongo.git"
+        "url":"http://github.com/zazengo/connect-session-mongo.git"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "connect-session-mongo",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "MongoDB Session Store for Connect Middleware",
     "author": "Bart Teeuwisse <bart@zazengo.com>",
     "contributors": ["Dav Glass <davglass@gmail.com>"],
@@ -15,7 +15,7 @@
     "main": "./lib/connect-session-mongo",
     "dependencies": {
         "connect": ">=0.2.4",
-        "mongodb": ">=0.7.9"
+        "mongodb": ">=0.8.0"
     },
     "licenses":[
         {


### PR DESCRIPTION
Dav,

you're storing a session as is in Mongo. Including the req attribute and the session's **proto**. When you read this back from Mongo it does overwrite the touch() function in the Session's prototype. This in turn breaks connect's session middleware.

I tested this with connect@0.3.0 and mongodb@0.8.0.
