### PR TITLE
dbopts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can also pass several options to the constructor to tweak your session store
 * port - The Port to connect to, defaults to: `27017`
 * collection - The collection to save it's data to, defaults to: `sessions`
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
+* dbopts - Options passed to mongodb.Db ctor (default is `{ native_parser: true }`)
 
 <pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
 app.use(xp.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -37,7 +37,9 @@ var MongoStore = function(options) {
         server= new Server(ip, port, {auto_reconnect: true}, {});
     }
 
-    this._db = new Db( dbName, server, { native_parser:true });
+    var dbopts = options.dbopts || { native_parser: true };
+
+    this._db = new Db( dbName, server, dbopts);
     this._db.open(function(db) {});
     
 }


### PR DESCRIPTION
Allow customizing the call to new mongodb.Db with options.
This is useful, for example, when you don't want the native parser to be used.
