### PR TITLE
Adds fsync: false option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 This module is an addon for ExpressJS that adds a new Session Storage device.
 
-
 ## Install
 
-    npm install express-session-mongo
+    npm install https://github.com/trottski/express-session-mongo/archive/master.tar.gz
 
 ## Usage
 
@@ -29,9 +28,26 @@ You can also pass several options to the constructor to tweak your session store
 * port - The Port to connect to, defaults to: `27017`
 * collection - The collection to save it's data to, defaults to: `sessions`
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
+* fsync - Confirm writes after they have been flushed to disk, default: false.
+* native_parser - Use BSON native parser, defaults to: true.
 
 <pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
 app.use(xp.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>
+
+## Removing stale sessions
+
+MongoDB 2.2 and above supports doing this via an index, see http://docs.mongodb.org/manual/tutorial/expire-data/
+To enable this, run
+
+    db.sessions.ensureIndex( { "lastAccess": 1 }, { expireAfterSeconds: 3600 } )
+
+Mongo will now remove all sessions older than an hour (every 60 seconds).
+
+## Changes from davglass/express-session-mongo
+
+1. Removes connect as a dependency
+2. Adds fsync and native_parser options to constructor
+3. Removes manual session cleanup cleanup code (see Removing stale sessions below)
 
 
 ## License

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -27,7 +27,9 @@ var MongoStore = function(options) {
     var server,
         dbName = (options.db) ? options.db : 'express-sessions',
         ip = (options.ip) ? options.ip : '127.0.0.1',
-        port = (options.port) ? options.port : 27017;
+        port = (options.port) ? options.port : 27017,
+        fsync = (typeof options.fsync !== 'undefined') ? options.fsync : false,
+        nativeParser = (typeof options.native_parser !== 'undefined') ? options.native_parser : true;
 
     this._collection = (options.collection) ? options.collection : 'sessions';
 
@@ -37,10 +39,9 @@ var MongoStore = function(options) {
         server= new Server(ip, port, {auto_reconnect: true}, {});
     }
 
-    this._db = new Db( dbName, server, { native_parser:true });
+    this._db = new Db(dbName, server, {fsync: fsync, native_parser: nativeParser});
     this._db.open(function(db) {});
-    
-}
+};
 
 util.inherits(MongoStore, Session.Store);
 
@@ -100,7 +101,6 @@ MongoStore.prototype.destroy = function(sid, fn) {
 MongoStore.prototype.length = function(fn) {
     this._db.collection(this._collection, function(err, collection) {
         collection.count(function(count) {
-            console.log('Session has: ', count);
             fn && fn(null, count);
         });
     });
@@ -139,7 +139,6 @@ var cleanSessionData = function(json) {
         
     }
     return data;
-}
-
+};
 
 module.exports = MongoStore;

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -15,15 +15,6 @@ var MongoStore = function(options) {
     options = options || {};
     Session.Store.call(this, options);
     
-    // Default reapInterval to 10 minutes
-    this.reapInterval = options.reapInterval || 600000;
-
-    if (this.reapInterval !== -1) {
-        setInterval(function(self){
-            self.reap(self.maxAge);
-        }, this.reapInterval, this);
-    }
-    
     var server,
         dbName = (options.db) ? options.db : 'express-sessions',
         ip = (options.ip) ? options.ip : '127.0.0.1',
@@ -45,13 +36,6 @@ var MongoStore = function(options) {
 
 util.inherits(MongoStore, Session.Store);
 
-MongoStore.prototype.reap = function(ms) {
-    var thresh = Number(new Date(Number(new Date) - ms));
-    this._db.collection(this._collection, function(err, collection) {
-        collection.remove({ "lastAccess" : { "$lt" : thresh }}, function() {});
-    });
-};
-
 MongoStore.prototype.set = function(sid, sess, fn) {
     this._db.collection(this._collection, function(err, collection) {
         collection.findOne({ _sessionid: sid }, function(err, session_data) {
@@ -61,7 +45,7 @@ MongoStore.prototype.set = function(sid, sess, fn) {
                 sess._sessionid = sid;
                 var method = 'insert';
                 if (session_data) {
-                    sess.lastAccess = (new Date()).getTime();
+                    sess.lastAccess = new Date()
                     method = 'save';
                 }
                 collection[method](sess, function(err, document) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "main": "./lib/express-session-mongo",
     "dependencies": {
         "express": ">=1.0.0rc4",
-        "connect": ">=0.2.4",
         "mongodb": ">=0.7.9"
     },
     "licenses":[


### PR DESCRIPTION
The current mongo driver displays a warning banner if you don't explicitly specify fsync or safe options.
