### PR TITLE
Consume existing mongo.Db, typo fix and some jsHint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The standard usage, is to just pass an instantiated `MongoStore` instance to the
 
 You can also pass several options to the constructor to tweak your session store:
 
-* db - The name of the db to use, defaults to: `express-sessions`
+* db - The name of the db to use, defaults to: `express-sessions` Or you can assign an existing mongo.Db instance
 * ip - The IP address of the server to connect to, defaults to: `127.0.0.1`
 * port - The Port to connect to, defaults to: `27017`
 * collection - The collection to save it's data to, defaults to: `sessions`

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -7,51 +7,60 @@ var mongo = require('mongodb'),
     util = require(process.binding('natives').util ? 'util' : 'sys'),
     Session = require('express').session,
     Db = mongo.Db,
-    Connection = mongo.Connection,
-    Server = mongo.Server,
-    BSON = mongo.BSONNative;
+    Server = mongo.Server;
 
-var MongoStore = function(options) {
+var MongoStore = function (options) {
+    'use strict';
+
     options = options || {};
     Session.Store.call(this, options);
-    
-    var server,
-        dbName = (options.db) ? options.db : 'express-sessions',
-        ip = (options.ip) ? options.ip : '127.0.0.1',
-        port = (options.port) ? options.port : 27017,
+
+    var self = this,
+        server,
+        db = options.db || 'express-sessions',// dbName = options.db || 'express-sessions',
+        ip = options.ip || '127.0.0.1',
+        port = options.port || 27017,
         fsync = (typeof options.fsync !== 'undefined') ? options.fsync : false,
         nativeParser = (typeof options.native_parser !== 'undefined') ? options.native_parser : true;
 
-    this._collection = (options.collection) ? options.collection : 'sessions';
+    self._collection = options.collection || 'sessions';
 
-    if (options.server) {
-        server = options.server;
-    } else {
-        server= new Server(ip, port, {auto_reconnect: true}, {});
+    if (db && typeof db === 'string') { //if db is passed in as dbName
+        if (options.server) {
+            server = options.server;
+        } else {
+            server = new Server(ip, port, {auto_reconnect: true}, {});
+        }
+        // treat db as dbName
+        self._db = new Db(db, server, {fsync: fsync, native_parser: nativeParser});
+        openMongoConn(self._db);
+    } else if (db && db instanceof Db) { //
+        self._db = db;
+
+        if (self._db.state !== 'connected') {
+            openMongoConn(self._db);
+        }
     }
-
-    this._db = new Db(dbName, server, {fsync: fsync, native_parser: nativeParser});
-    this._db.open(function(db) {});
 };
 
 util.inherits(MongoStore, Session.Store);
 
-MongoStore.prototype.set = function(sid, sess, fn) {
-    this._db.collection(this._collection, function(err, collection) {
-        collection.findOne({ _sessionid: sid }, function(err, session_data) {
-            if (err) {
-                fn && fn(error);
+MongoStore.prototype.set = function (sid, sess, fn) {
+    'use strict';
+    this._db.collection(this._collection, function (err, collection) {
+        collection.findOne({ _sessionid: sid }, function (err, session_data) {
+            if (err && fn) {
+                fn(err);
             } else {
                 sess._sessionid = sid;
                 var method = 'insert';
                 if (session_data) {
-                    sess.lastAccess = new Date()
+                    sess.lastAccess = new Date();
                     method = 'save';
                 }
-                collection[method](sess, function(err, document) {
-                    if (err) {
-                    } else { 
-                        fn && fn(null, sess);
+                collection[method](sess, function (err, document) {
+                    if (!err && fn) {
+                        fn(null, sess);
                     }
                 });
             }
@@ -59,12 +68,13 @@ MongoStore.prototype.set = function(sid, sess, fn) {
     });
 };
 
-MongoStore.prototype.get = function(sid, fn) {
-    this._db.collection(this._collection, function(err, collection) {
-        collection.findOne({ _sessionid: sid }, function(err, session_data) {
-            if (err) {
-                fn && fn(error);
-            } else { 
+MongoStore.prototype.get = function (sid, fn) {
+    'use strict';
+    this._db.collection(this._collection, function (err, collection) {
+        collection.findOne({ _sessionid: sid }, function (err, session_data) {
+            if (err && fn) {
+                fn(err);
+            } else {
                 if (session_data) {
                     session_data = cleanSessionData(session_data);
                 }
@@ -74,27 +84,30 @@ MongoStore.prototype.get = function(sid, fn) {
     });
 };
 
-MongoStore.prototype.destroy = function(sid, fn) {
-    this._db.collection(this._collection, function(err, collection) {
-        collection.remove({ _sessionid: sid }, function() {
+MongoStore.prototype.destroy = function (sid, fn) {
+    'use strict';
+    this._db.collection(this._collection, function (err, collection) {
+        collection.remove({ _sessionid: sid }, function () {
             fn && fn();
         });
     });
 };
 
-MongoStore.prototype.length = function(fn) {
-    this._db.collection(this._collection, function(err, collection) {
-        collection.count(function(count) {
+MongoStore.prototype.length = function (fn) {
+    'use strict';
+    this._db.collection(this._collection, function (err, collection) {
+        collection.count(function (count) {
             fn && fn(null, count);
         });
     });
 };
 
-MongoStore.prototype.all = function() {
+MongoStore.prototype.all = function () {
+    'use strict';
     var arr = [];
-    this._db.collection(this._collection, function(err, collection) {
-        collection.find(function(err, cursor) {
-            cursor.each(function(d) {
+    this._db.collection(this._collection, function (err, collection) {
+        collection.find(function (err, cursor) {
+            cursor.each(function (d) {
                 d = cleanSessionData(d);
                 arr.push(d);
             });
@@ -103,7 +116,8 @@ MongoStore.prototype.all = function() {
     });
 };
 
-MongoStore.prototype.clear = function() {
+MongoStore.prototype.clear = function () {
+    'use strict';
     this._db.collection(this._collection, function(err, collection) {
         collection.remove(function() {
             fn && fn();
@@ -111,18 +125,28 @@ MongoStore.prototype.clear = function() {
     });
 };
 
-var cleanSessionData = function(json) {
-    var data = {};
-    for (var i in json) {
+var cleanSessionData = function (json) {
+    'use strict';
+    var data = {},
+        i = 0;
+    for (i in json) {
         data[i] = json[i];
         if (data[i] instanceof Object) {
             if ('low_' in data[i] || 'high_' in data[i]) {
                 data[i] = data[i].toNumber();
             }
         }
-        
     }
     return data;
 };
+
+function openMongoConn(db) {
+    'use strict';
+    db.open(function (err) {
+        if (err) {
+            throw err;
+        }
+    });
+}
 
 module.exports = MongoStore;


### PR DESCRIPTION
First of all i will thank you to get time and write this package for community. 

I was using this package in one of my app, but i wanted to use existing mongo connection(with replicaset settings), but not found the way to do it with current version, so i added in my stuff to handle existing mongo.Db instance. Also i fixed 2 of the typos and did some jsHint cleaning.

I hope these changes can help improve the current version.

Excuse me if that makes no senses to package.

Thanks
