### PR TITLE
fixes #17, fixes undefined on findOne faiure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You can also pass several options to the constructor to tweak your session store
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
 * fsync - Confirm writes after they have been flushed to disk, default: false.
 * native_parser - Use BSON native parser, defaults to: true.
+* username - The username for the database.
+* password - The password which corresponds to the database
+* authenciated - An err-first callback that fires once connected and an auth attempt is made.
 
 <pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
 app.use(xp.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -40,7 +40,7 @@ MongoStore.prototype.set = function(sid, sess, fn) {
     this._db.collection(this._collection, function(err, collection) {
         collection.findOne({ _sessionid: sid }, function(err, session_data) {
             if (err) {
-                fn && fn(error);
+                fn && fn(err);
             } else {
                 sess._sessionid = sid;
                 var method = 'insert';
@@ -63,7 +63,7 @@ MongoStore.prototype.get = function(sid, fn) {
     this._db.collection(this._collection, function(err, collection) {
         collection.findOne({ _sessionid: sid }, function(err, session_data) {
             if (err) {
-                fn && fn(error);
+                fn && fn(err);
             } else { 
                 if (session_data) {
                     session_data = cleanSessionData(session_data);

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -31,7 +31,13 @@ var MongoStore = function(options) {
     }
 
     this._db = new Db(dbName, server, {fsync: fsync, native_parser: nativeParser});
-    this._db.open(function(db) {});
+    this._db.open(function(err, db) {
+        if (options.username && options.password) {
+            db.authenticate(options.username, options.password, function(err, results) {
+                (options.authenticated || function() {})(err, results);
+            });
+        }
+    });
 };
 
 util.inherits(MongoStore, Session.Store);


### PR DESCRIPTION
Attempting to findOne can encounter an error (such as unauthorized, etc.). When an error happens, you were invoking `fn` with `error` instead of `err`.  Now, we pass back the correct reference.
