### PR TITLE
adding authentication mechanism, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You can also pass several options to the constructor to tweak your session store
 * server - A custom mongo Server instance (this overides db, ip &amp; port):
 * fsync - Confirm writes after they have been flushed to disk, default: false.
 * native_parser - Use BSON native parser, defaults to: true.
+* username - The username for the database.
+* password - The password which corresponds to the database
+* authenciated - An err-first callback that fires once connected and an auth attempt is made.
 
 <pre><code>var CustomServer = new Server(123.456.789.1, 12345, { auto_reconnect: true }, {});
 app.use(xp.session({ store: new MongoStore({ server: CustomServer }) }));</code></pre>

--- a/lib/express-session-mongo.js
+++ b/lib/express-session-mongo.js
@@ -31,7 +31,13 @@ var MongoStore = function(options) {
     }
 
     this._db = new Db(dbName, server, {fsync: fsync, native_parser: nativeParser});
-    this._db.open(function(db) {});
+    this._db.open(function(err, db) {
+        if (options.username && options.password) {
+            db.authenticate(options.username, options.password, function(err, results) {
+                (options.authenticated || function() {})(err, results);
+            });
+        }
+    });
 };
 
 util.inherits(MongoStore, Session.Store);


### PR DESCRIPTION
Previously, there was no way for an express-session-mongo instance to connect to a database with authentication turned on. 

I added three configuration options, a username and password, and a err-back.
